### PR TITLE
Use EventSource#close method

### DIFF
--- a/jquery.eventsource.js
+++ b/jquery.eventsource.js
@@ -41,6 +41,12 @@
 				var tmp = {};
 
 				if ( !label || label === "*" ) {
+					for ( var prop in stream.cache ) {
+						if ( stream.cache[ prop ].isHostApi ) {
+							stream.cache[ prop ].stream.close();
+						}
+					}
+
 					stream.cache = {};
 
 					return stream.cache;
@@ -49,6 +55,10 @@
 				for ( var prop in stream.cache ) {
 					if ( label !== prop ) {
 						tmp[ prop ] = stream.cache[ prop ];
+					} else {
+						if ( stream.cache[ prop ].isHostApi ) {
+							stream.cache[ prop ].stream.close();
+						}
 					}
 				}
 


### PR DESCRIPTION
Unlinking the object (as done in the current version) doesn't close the underlying connection.
Should use EventSource#close method to really close it.
More here: http://www.w3.org/TR/eventsource/#the-eventsource-interface
